### PR TITLE
add serialport address for Jiangsu Qinheng Co., Ltd. CH34x driver

### DIFF
--- a/Interface_Programs/GBxCart_RW_Console_Flasher_v1.11/rs232/rs232.c
+++ b/Interface_Programs/GBxCart_RW_Console_Flasher_v1.11/rs232/rs232.c
@@ -40,7 +40,7 @@
 #include <IOKit/serial/ioss.h>
 #endif
 
-#define RS232_PORTNR  40
+#define RS232_PORTNR  41
 
 
 int Cport[RS232_PORTNR],
@@ -57,7 +57,7 @@ char *comports[RS232_PORTNR]={"/dev/ttyS0","/dev/ttyS1","/dev/ttyS2","/dev/ttyS3
                        "/dev/rfcomm0","/dev/rfcomm1","/dev/ircomm0","/dev/ircomm1",
                        "/dev/cuau0","/dev/cuau1","/dev/cuau2","/dev/cuau3",
                        "/dev/cuaU0","/dev/cuaU1","/dev/cuaU2","/dev/cuaU3",
-                       "/dev/tty.wchusbserial1430","/dev/tty.wchusbserial630"};
+                       "/dev/tty.wchusbserial1430","/dev/tty.wchusbserial630","/dev/tty.wchusbserial1410"};
 
 int RS232_OpenComport(int comport_number, int baudrate, const char *mode)
 {

--- a/Interface_Programs/GBxCart_RW_Console_Interface_v1.15/rs232/rs232.c
+++ b/Interface_Programs/GBxCart_RW_Console_Interface_v1.15/rs232/rs232.c
@@ -40,7 +40,7 @@
 #include <IOKit/serial/ioss.h>
 #endif
 
-#define RS232_PORTNR  40
+#define RS232_PORTNR  41
 
 
 int Cport[RS232_PORTNR],
@@ -57,7 +57,7 @@ char *comports[RS232_PORTNR]={"/dev/ttyS0","/dev/ttyS1","/dev/ttyS2","/dev/ttyS3
                        "/dev/rfcomm0","/dev/rfcomm1","/dev/ircomm0","/dev/ircomm1",
                        "/dev/cuau0","/dev/cuau1","/dev/cuau2","/dev/cuau3",
                        "/dev/cuaU0","/dev/cuaU1","/dev/cuaU2","/dev/cuaU3",
-                       "/dev/tty.wchusbserial1430","/dev/tty.wchusbserial630"};
+                       "/dev/tty.wchusbserial1430","/dev/tty.wchusbserial630","/dev/tty.wchusbserial1410"};
 
 int RS232_OpenComport(int comport_number, int baudrate, const char *mode)
 {

--- a/Interface_Programs/GBxCart_RW_GBCamera_Saver_v1.4/rs232/rs232.c
+++ b/Interface_Programs/GBxCart_RW_GBCamera_Saver_v1.4/rs232/rs232.c
@@ -40,7 +40,7 @@
 #include <IOKit/serial/ioss.h>
 #endif
 
-#define RS232_PORTNR  40
+#define RS232_PORTNR  41
 
 
 int Cport[RS232_PORTNR],
@@ -57,7 +57,7 @@ char *comports[RS232_PORTNR]={"/dev/ttyS0","/dev/ttyS1","/dev/ttyS2","/dev/ttyS3
                        "/dev/rfcomm0","/dev/rfcomm1","/dev/ircomm0","/dev/ircomm1",
                        "/dev/cuau0","/dev/cuau1","/dev/cuau2","/dev/cuau3",
                        "/dev/cuaU0","/dev/cuaU1","/dev/cuaU2","/dev/cuaU3",
-                       "/dev/tty.wchusbserial1430","/dev/tty.wchusbserial630"};
+                       "/dev/tty.wchusbserial1430","/dev/tty.wchusbserial630","/dev/tty.wchusbserial1410"};
 
 int RS232_OpenComport(int comport_number, int baudrate, const char *mode)
 {


### PR DESCRIPTION
On OSX 10.13.3 was able to get only Jiangsu Qinheng CH34X driver to work. It uses port /dev/tty.wchusbserial1410 instead of 1430.